### PR TITLE
Fix tests to support asynchronous execution

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     application
-    kotlin("jvm") version "1.4.32"
+    kotlin("jvm") version "1.5.20"
     id("org.openjfx.javafxplugin") version "0.0.9"
 }
 
@@ -19,6 +19,8 @@ dependencies {
 
     testImplementation(platform("org.junit:junit-bom:5.7.1"))
     testImplementation("org.junit.jupiter:junit-jupiter")
+
+    testImplementation("org.awaitility:awaitility-kotlin:4.1.0")
 
     implementation("io.github.microutils:kotlin-logging-jvm:2.0.6")
     implementation("org.slf4j:slf4j-simple:1.7.30")

--- a/src/test/kotlin/ru/spbu/netter/TxtIOIntegrationTests.kt
+++ b/src/test/kotlin/ru/spbu/netter/TxtIOIntegrationTests.kt
@@ -3,6 +3,8 @@ package ru.spbu.netter
 import javafx.application.Platform
 import org.awaitility.kotlin.await
 import org.awaitility.kotlin.until
+import org.awaitility.kotlin.withPollInterval
+import org.awaitility.pollinterval.FibonacciPollInterval.fibonacci
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
@@ -115,7 +117,7 @@ internal class TxtIOIntegrationTests {
         actions.forEachIndexed { i, action ->
             with(action) { callBy(mapOf(parameters.first() to network, parameters.last() to { flags[i] = true })) }
         }
-        await until { flags.all { it } }
+        await withPollInterval fibonacci() until { flags.all { it } }
 
         val expectedNodes = network.getSimpleNodes()
         val expectedLinks = network.getLinksAsPairs()


### PR DESCRIPTION
Existing tests are fixed to correctly function with asynchronous execution added earlier.

In particular, the following changes were made:
- `Platform.startup {}` is run before all tests to ensure that JavaFX toolkit is initialized before the execution of netter's controllers
- [Awaitility](https://github.com/awaitility/awaitility) library is now used to make the assertions wait until all the asynchronous tasks are finished
- Kotlin is updated to version 1.5.20